### PR TITLE
Use tmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,16 +28,18 @@ before_script:
 
 jobs:
   allow_failures:
-    - name: codeclimate
+    - name: test
   include:
     - stage: test
-      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json
+      name: test
+      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: rspec
           paths: /tmp/coverage
     - stage: test
-      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json
+      name: test
+      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: cucumber
@@ -55,5 +57,5 @@ jobs:
         use:
           - rspec
           - cucumber
-      script: cd /tmp/coverage && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json
+      script: cd /tmp/coverage && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json && if [ -f /tmp/coverage/fail ]; exit 1; fi
       # if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,8 @@ before_script:
 
 
 jobs:
-  allow_failures:
-    - name: test
-    - name: codeclimate
   include:
     - stage: test
-      name: test
       script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json
       workspaces:
         create:
@@ -45,7 +41,6 @@ jobs:
           name: cucumber
           paths: /tmp/coverage
     - stage: codeclimate
-      name: codeclimate
       git:
         clone: false
       language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     - stage: test
       script: 
         - bundle exec rspec
-        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && ls -alFX /tmp/coverage && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "RSPEC_FAIL" && exit 1; else echo "RSPEC_PASS"; fi
+        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && ls -alFX /tmp/coverage && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "RSPEC_FAIL"; else echo "RSPEC_PASS"; fi
       workspaces:
         create:
           name: rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,12 @@ before_script:
 
 
 jobs:
+  allow_failures:
+    - name: test
+    - name: codeclimate
   include:
     - stage: test
+      name: test
       script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json
       workspaces:
         create:
@@ -41,6 +45,7 @@ jobs:
           name: cucumber
           paths: /tmp/coverage
     - stage: codeclimate
+      name: codeclimate
       git:
         clone: false
       language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ before_script:
 
 
 jobs:
+  allow_failures:
+    - name: codeclimate
   include:
     - stage: test
       script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json
@@ -41,6 +43,7 @@ jobs:
           name: cucumber
           paths: /tmp/coverage
     - stage: codeclimate
+      name: codeclimate
       git:
         clone: false
       language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,15 @@ jobs:
     - stage: test
       script: 
         - bundle exec rspec
-        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && ls -alFX /tmp/coverage && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "RSPEC_FAIL"; else echo "RSPEC_PASS"; fi
+        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: rspec
           paths: /tmp/coverage
     - stage: test
-      script: bundle exec cucumber; STATUS=$?; /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json; ls -alFX /tmp/coverage; if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "CUCUMBER_FAIL" && exit 1; else echo "CUCUMBER_PASS"; fi
+      script:
+        - bundle exec cucumber
+        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: cucumber
@@ -46,5 +48,5 @@ jobs:
         use:
           - rspec
           - cucumber
-      script: cd /tmp/coverage && ls -alFX && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json && if [ -f /tmp/coverage/fail ]; then echo "FFAAIILL"; exit 1; else echo "PPAASSSS"; fi
+      script: cd /tmp/coverage && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json && if [ -f /tmp/coverage/fail ]; then exit 1; fi
       # if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ rvm:
 before_script:
   - mysql -e 'CREATE DATABASE bio_test;'
   - "cp .travis.database.yml ./config/database.yml"
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /tmp/cc-test-reporter
-  - chmod +x /tmp/cc-test-reporter
-  - /tmp/cc-test-reporter before-build
+  - mkdir -p /tmp/coverage && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /tmp/coverage/cc-test-reporter
+  - chmod +x /tmp/coverage/cc-test-reporter
+  - /tmp/coverage/cc-test-reporter before-build
 
 # jobs:
 #   include:
@@ -29,17 +29,17 @@ before_script:
 jobs:
   include:
     - stage: test
-      script: bundle exec rspec && /tmp/cc-test-reporter format-coverage -t simplecov -o /tmp/codeclimate.rspec.json
+      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json
       workspaces:
         create:
           name: rspec
-          paths: /tmp
+          paths: /tmp/coverage
     - stage: test
-      script: bundle exec cucumber && /tmp/cc-test-reporter format-coverage -t simplecov -o /tmp/codeclimate.cucumber.json
+      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json
       workspaces:
         create:
           name: cucumber
-          paths: /tmp
+          paths: /tmp/coverage
     - stage: codeclimate
       git:
         clone: false
@@ -52,4 +52,4 @@ jobs:
         use:
           - rspec
           - cucumber
-      script: cd /tmp && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json
+      script: cd /tmp/coverage && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,24 +18,23 @@ before_script:
 
 jobs:
   allow_failures:
-    - name: test
+    - stage: test
   include:
     - stage: test
-      name: test
-      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; then touch /tmp/coverage/fail; fi
+      script: 
+        - bundle exec rspec
+        - STATUS=$? && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && ls -alFX /tmp/coverage && if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "RSPEC_FAIL" && exit 1; else echo "RSPEC_PASS"; fi
       workspaces:
         create:
           name: rspec
           paths: /tmp/coverage
     - stage: test
-      name: test
-      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; then touch /tmp/coverage/fail; fi
+      script: bundle exec cucumber; STATUS=$?; /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json; ls -alFX /tmp/coverage; if [[ "$STATUS" == 1 ]]; then touch /tmp/coverage/fail && echo "CUCUMBER_FAIL" && exit 1; else echo "CUCUMBER_PASS"; fi
       workspaces:
         create:
           name: cucumber
           paths: /tmp/coverage
     - stage: codeclimate
-      name: codeclimate
       git:
         clone: false
       language: minimal
@@ -47,5 +46,5 @@ jobs:
         use:
           - rspec
           - cucumber
-      script: cd /tmp/coverage && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json && if [ -f /tmp/coverage/fail ]; then exit 1; fi
+      script: cd /tmp/coverage && ls -alFX && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json && if [ -f /tmp/coverage/fail ]; then echo "FFAAIILL"; exit 1; else echo "PPAASSSS"; fi
       # if: branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ rvm:
 before_script:
   - mysql -e 'CREATE DATABASE bio_test;'
   - "cp .travis.database.yml ./config/database.yml"
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /tmp/cc-test-reporter
+  - chmod +x /tmp/cc-test-reporter
+  - /tmp/cc-test-reporter before-build
 
 # jobs:
 #   include:
@@ -29,17 +29,17 @@ before_script:
 jobs:
   include:
     - stage: test
-      script: bundle exec rspec && ./cc-test-reporter format-coverage -t simplecov -o codeclimate.rspec.json
+      script: bundle exec rspec && /tmp/cc-test-reporter format-coverage -t simplecov -o /tmp/codeclimate.rspec.json
       workspaces:
         create:
           name: rspec
-          paths: .
+          paths: /tmp
     - stage: test
-      script: bundle exec cucumber && ./cc-test-reporter format-coverage -t simplecov -o codeclimate.cucumber.json
+      script: bundle exec cucumber && /tmp/cc-test-reporter format-coverage -t simplecov -o /tmp/codeclimate.cucumber.json
       workspaces:
         create:
           name: cucumber
-          paths: .
+          paths: /tmp
     - stage: codeclimate
       git:
         clone: false
@@ -52,4 +52,4 @@ jobs:
         use:
           - rspec
           - cucumber
-      script: mkdir -p regic/rails5 && cd regic/rails5 && ls -alFX && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json
+      script: cd /tmp && ./cc-test-reporter sum-coverage codeclimate.*.json -p 2 -o codeclimate.json && ./cc-test-reporter upload-coverage -i codeclimate.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ jobs:
   include:
     - stage: test
       name: test
-      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; touch /tmp/coverage/fail; fi
+      script: bundle exec rspec && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.rspec.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; then touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: rspec
           paths: /tmp/coverage
     - stage: test
       name: test
-      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; touch /tmp/coverage/fail; fi
+      script: bundle exec cucumber && /tmp/coverage/cc-test-reporter format-coverage -t simplecov -o /tmp/coverage/codeclimate.cucumber.json && if [ "$TRAVIS_TEST_RESULT" == 1 ]; then touch /tmp/coverage/fail; fi
       workspaces:
         create:
           name: cucumber

--- a/spec/success_spec.rb
+++ b/spec/success_spec.rb
@@ -1,5 +1,5 @@
 describe "success" do
   it "succeeds" do
-    expect(true).to be true
+    expect(false).to be true
   end
 end


### PR DESCRIPTION
If we still want to allow upload of test coverage when one of the jobs fail we need to
1. Allow spec jobs to fail but do not allow test coverage upload job to fail
2. Create file in case of failure for each job (e.g. `failed.out`)
3. Upload the test coverage and fail the job in case there is `failed.out` file for one of the specs (which will fail the whole build)